### PR TITLE
Ensure consistent ring buffer behavior during impulse response changes

### DIFF
--- a/src/fft_convolver.rs
+++ b/src/fft_convolver.rs
@@ -133,7 +133,7 @@ impl Convolution for FFTConvolver {
         let block_size = block_size.next_power_of_two();
         let seg_size = 2 * block_size;
         let seg_count = (max_response_length as f64 / block_size as f64).ceil() as usize;
-        let active_seg_count = seg_count;
+        let active_seg_count = (ir_len as f64 / block_size as f64).ceil() as usize;
         let fft_complex_size = complex_size(seg_size);
 
         // FFT

--- a/src/fft_convolver.rs
+++ b/src/fft_convolver.rs
@@ -265,7 +265,7 @@ impl Convolution for FFTConvolver {
                 self.pre_multiplied.fill(Complex { re: 0., im: 0. });
                 for i in 1..self.active_seg_count {
                     let index_ir = i;
-                    let index_audio = (self.current + i) % self.active_seg_count;
+                    let index_audio = (self.current + i) % self.seg_count;
                     complex_multiply_accumulate(
                         &mut self.pre_multiplied,
                         &self.segments_ir[index_ir],
@@ -307,7 +307,7 @@ impl Convolution for FFTConvolver {
                 self.current = if self.current > 0 {
                     self.current - 1
                 } else {
-                    self.active_seg_count - 1
+                    self.seg_count - 1
                 };
             }
             processed += processing;

--- a/src/fft_convolver.rs
+++ b/src/fft_convolver.rs
@@ -101,7 +101,7 @@ pub fn sum(result: &mut [f32], a: &[f32], b: &[f32]) {
 }
 #[derive(Default, Clone)]
 pub struct FFTConvolver {
-    ir_len: usize,
+    max_response_length: usize,
     block_size: usize,
     _seg_size: usize,
     seg_count: usize,
@@ -126,13 +126,13 @@ impl Convolution for FFTConvolver {
                 "max_response_length must be at least the length of the initial impulse response"
             );
         }
+        let ir_len = impulse_response.len();
         let mut padded_ir = impulse_response.to_vec();
         padded_ir.resize(max_response_length, 0.);
-        let ir_len = padded_ir.len();
 
         let block_size = block_size.next_power_of_two();
         let seg_size = 2 * block_size;
-        let seg_count = (ir_len as f64 / block_size as f64).ceil() as usize;
+        let seg_count = (max_response_length as f64 / block_size as f64).ceil() as usize;
         let active_seg_count = seg_count;
         let fft_complex_size = complex_size(seg_size);
 
@@ -148,7 +148,7 @@ impl Convolution for FFTConvolver {
         // prepare ir
         for i in 0..seg_count {
             let mut segment = vec![Complex::new(0., 0.); fft_complex_size];
-            let remaining = ir_len - (i * block_size);
+            let remaining = max_response_length - (i * block_size);
             let size_copy = if remaining >= block_size {
                 block_size
             } else {
@@ -172,7 +172,7 @@ impl Convolution for FFTConvolver {
         let current = 0;
 
         Self {
-            ir_len,
+            max_response_length,
             block_size,
             _seg_size: seg_size,
             seg_count,
@@ -194,11 +194,11 @@ impl Convolution for FFTConvolver {
     fn update(&mut self, response: &[Sample]) {
         let new_ir_len = response.len();
 
-        if new_ir_len > self.ir_len {
-            panic!("New impulse response is longer than initialized length");
+        if new_ir_len > self.max_response_length {
+            panic!("New impulse response is longer than max response length");
         }
 
-        if self.ir_len == 0 {
+        if self.max_response_length == 0 {
             return;
         }
 


### PR DESCRIPTION
- Clarifies distinction between initial and maximum IR length
- Differentiates between `seg_count` (total allocated IR partitions) and `active_segment_count` (number of nonzero IR partitions)
- Fixes an issue where the `current` index of the input ring buffer (`self.segments`) incorrectly cycled through `active_seg_count` rather than `seg_count`
  - This could cause invalid indexing when `active_seg_count` changes during filter switches